### PR TITLE
Include appropiate libvirt-python package in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,8 @@ LABEL ROOT-UNINSTALL="/usr/bin/podman run --rm --security-opt label=disable -v /
 LABEL USER-INSTALL="/usr/bin/podman run --env IMAGE=IMAGE --security-opt label=disable --rm -v \${PWD}/:/host IMAGE /bin/bash /container/label-install"
 LABEL USER-UNINSTALL="/usr/bin/podman run --rm --security-opt label=disable -v \${PWD}/:/host IMAGE /bin/bash /container/label-uninstall"
 
-RUN zypper -v -n in ansible-core ansible openssh-clients; zypper clean --all
+RUN zypper -v -n in ansible-core ansible openssh-clients; \
+    pyver=$(python3 --version | cut -d ' ' -f2 | cut -d. -f1-2 | tr -d .); \
+    zypper -v -n in python${pyver}-python-libvirt; \
+    zypper clean --all
 


### PR DESCRIPTION
To support integration of Ansible with Libvirt we need to ensure that the appropriate Python version specific libvirt-python package is installed in the container image.