### PR TITLE
Use git-core instead of git to reduce unnecessary dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN zypper -v -n in \
         ansible-core \
         ansible \
         ansible-test \
+        git-core \
         openssh-clients \
-        git \
         python3-libvirt-python \
         python3-netaddr \
     ; \


### PR DESCRIPTION
The git package pulls in a number of additional packages, including perl ones, that we don't really need or care about; switching to git-core avoids the unnecessary dependencies being installed.

Also alphabetically sorted the package list.