### PR TITLE
Copy examples directory into /container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,13 @@ LABEL com.suse.release-stage="alpha"
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-RUN mkdir /container
+RUN mkdir -p /container
 COPY label-install \
      label-uninstall \
      ansible-wrapper.sh \
      hosts_alphost_group \
      /container
+ADD examples/ /container/examples
 RUN chmod +x /container/ansible-wrapper.sh
 
 WORKDIR /work

--- a/label-install
+++ b/label-install
@@ -1,15 +1,15 @@
 #!/bin/sh
 create_command_bin() {
 SCRIPT=$1
-if [ ! -e ${TARGET}/${SCRIPT} ]; then
-        cd ${TARGET}; ln -s ansible-wrapper.sh ${SCRIPT}
+if [ ! -e ${TARGET_BIN}/${SCRIPT} ]; then
+        cd ${TARGET_BIN}; ln -s ansible-wrapper.sh ${SCRIPT}
 else
-        echo "${TARGET}/${SCRIPT} already exist, will not update it"
+        echo "${TARGET_BIN}/${SCRIPT} already exist, will not update it"
 fi
 }
 
-if [ ! -e ${TARGET}/${SCRIPT} ]; then
-        echo "Failed to create ${TARGET}/${SCRIPT}"
+if [ ! -e ${TARGET_BIN}/${SCRIPT} ]; then
+        echo "Failed to create ${TARGET_BIN}/${SCRIPT}"
         exit 1
 fi
 
@@ -27,20 +27,30 @@ ansible-inventory \
 ansible-test \
 ansible-pull"
 
-# determime target directory
-# either /usrlocalbin or current user bin
+# determime target root directory
+# either /usr/local/bin or current user ~/bin
 if [ -d /host/usr/local/bin ]; then
-        TARGET=/host/usr/local/bin
+        TARGET_ROOT=/host/usr/local
 elif [ -d /host/bin ] ; then
-        TARGET=/host/bin
+        TARGET_ROOT=/host
 else
         echo "could not determine copy target"
         exit 1
 fi
 
-cp /container/ansible-wrapper.sh ${TARGET}/ansible-wrapper.sh
+TARGET_BIN=${TARGET_ROOT}/bin
+TARGET_SHARE=${TARGET_ROOT}/share/ansible-container
+
+cp -v /container/ansible-wrapper.sh ${TARGET_BIN}/ansible-wrapper.sh
 
 for COMMAND in ${COMMANDS}; do
     create_command_bin ${COMMAND}
 done
 
+# Create container share area under /usr/local/share if it doesn't exist
+if [ ! -d ${TARGET_SHARE} ]; then
+        mkdir -p ${TARGET_SHARE}
+fi
+
+# Copy examples to container share area, overwriting any previous content.
+cp -av /container/examples ${TARGET_SHARE}/

--- a/label-uninstall
+++ b/label-uninstall
@@ -2,11 +2,11 @@
 delete_file() {
 FILE=$1
 if [[ -e "/host/bin/${FILE}" || -L "/host/bin/${FILE}" ]]; then
-	/usr/bin/rm -vf /host/bin/${FILE}
+    /usr/bin/rm -vf /host/bin/${FILE}
 elif [[ -e "/host/usr/local/bin/${FILE}" || -L "/host/usr/local/bin/${FILE}" ]]; then
-        /usr/bin/rm -vf /host/usr/local/bin/${FILE}
+    /usr/bin/rm -vf /host/usr/local/bin/${FILE}
 else
-	echo "${FILE} not present, nothing to remove"
+    echo "${FILE} not present, nothing to remove"
 fi
 }
 
@@ -27,5 +27,9 @@ ansible-pull"
 for COMMAND in ${COMMANDS}; do
     delete_file ${COMMAND}
 done
+
+if [ -d /host/usr/local/share/ansible-container ]; then
+    rm -rf /host/usr/local/share/ansible-container
+fi
 
 exit 0


### PR DESCRIPTION
Include the examples directory in the container image under /container.

Also update label-install & label-uninstall to install or uninstall the examples under /usr/local/share/ansible-container.