### PR TITLE
Enable virt_net in create_tumbleweed_vm.yml playbook

### DIFF
--- a/examples/ansible/create_tumbleweed_vm.yml
+++ b/examples/ansible/create_tumbleweed_vm.yml
@@ -45,14 +45,11 @@
       community.libvirt.virt_net:
         command: list_nets
       register: virt_net_list_nets
-      when:
-        - false  # doesn't work for now - remove when python3-lxml available
 
     - name: Fail if required network is not available
       fail:
         msg: "ERROR: required '{{ libvirt.network }}' missing!"
       when:
-        - virt_net_list_nets is not skipped  # remove when python3-lxml available
         - libvirt.network not in virt_net_list_nets.list_nets
 
     - name: Query list of libvirt VMs

--- a/examples/ansible/setup_libvirt_host.yml
+++ b/examples/ansible/setup_libvirt_host.yml
@@ -17,9 +17,9 @@
       required_pkgs:
         - kernel-default
         - "-kernel-default-base"
-#       - netcat-openbsd  # uncomment once available
+        - netcat-openbsd
         - python3-libvirt-python
-#       - python3-lxml  # uncomment once available
+        - python3-lxml
       service:
         name: libvirtd
         wait_for:


### PR DESCRIPTION
The python3-lxml package is needed on the host system to support the community.libvirt.virt_net module.

Also enable the installation of netcat-openbsd to allow remote access to the Libvirt services via qemu+ssh.