### PR TITLE
Use full image path rather than shortname in wrapper

### DIFF
--- a/ansible-wrapper.sh
+++ b/ansible-wrapper.sh
@@ -1,6 +1,14 @@
 #! /bin/sh
 PATH=/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin
 
+IMAGE=registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/ansible:latest
+for cnf in /etc/default/ansible-container ~/.config/ansible-container/image
+do
+    if [ -r ${cnf} ]; then
+        . ${cnf}
+    fi
+done
+
 KEED_USERID=""
 if [[ $(id -ru) != "0" ]]; then
     KEED_USERID="--userns=keep-id"
@@ -12,7 +20,7 @@ LINK_DIR=`mktemp -d -p /tmp`
 ln -s $(pwd)  ${LINK_DIR}/work
 ln -s ${HOME} ${LINK_DIR}/home
 
-podman run  --security-opt label=disable -it -v ${LINK_DIR}/work:/work -v ${LINK_DIR}/home:${HOME} ${KEED_USERID} --rm ansible "$(basename "${0}")" "$@"
+podman run  --security-opt label=disable -it -v ${LINK_DIR}/work:/work -v ${LINK_DIR}/home:${HOME} ${KEED_USERID} --rm ${IMAGE} "$(basename "${0}")" "$@"
 
 # clean up symlink area
 rm ${LINK_DIR}/work ${LINK_DIR}/home

--- a/label-install
+++ b/label-install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 create_command_bin() {
 SCRIPT=$1
 if [ ! -e ${TARGET_BIN}/${SCRIPT} ]; then
@@ -32,8 +32,12 @@ ansible-pull"
 # either /usr/local/bin or current user ~/bin
 if [ -d /host/usr/local/bin ]; then
         TARGET_ROOT=/host/usr/local
+        IMAGE_CONF_DIR=etc/default
+        IMAGE_CONF_FILE=ansible-container
 elif [ -d /host/bin ] ; then
         TARGET_ROOT=/host
+        IMAGE_CONF_DIR=.config/ansible-container
+        IMAGE_CONF_FILE=image
 else
         echo "could not determine copy target"
         exit 1
@@ -41,6 +45,7 @@ fi
 
 TARGET_BIN=${TARGET_ROOT}/bin
 TARGET_SHARE=${TARGET_ROOT}/share/ansible-container
+TARGET_CONF_DIR=${TARGET_ROOT}/${IMAGE_CONF_DIR}
 
 cp -v /container/ansible-wrapper.sh ${TARGET_BIN}/ansible-wrapper.sh
 
@@ -55,3 +60,10 @@ fi
 
 # Copy examples to container share area, overwriting any previous content.
 cp -av /container/examples ${TARGET_SHARE}/
+
+# Save container image used to install the container to appropriate conf
+# file
+if [ ! -d ${TARGET_CONF_DIR} ]; then
+        mkdir -p ${TARGET_CONF_DIR}
+fi
+echo "IMAGE=${IMAGE}" > ${TARGET_CONF_DIR}/${IMAGE_CONF_FILE}

--- a/label-uninstall
+++ b/label-uninstall
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 delete_file() {
 FILE=$1
 if [[ -e "/host/bin/${FILE}" || -L "/host/bin/${FILE}" ]]; then


### PR DESCRIPTION
When running ansible commands via the wrapper script we should use the full image path rather than the short name for the Ansible container image.

Allow the default full image path to be superseded by settings in /etc/default/ansible-conatiner and ~/.config/ansible-container/image.

Update label-install to save the image used to do the install to the appropriate settings file, e.g. /etc/default/ansible-container for root installs, and ~/.config/ansible-container/image for user mode installs.

Update shebang line shells for label-install/uninstall scripts to reflect the shell used to run then by the podman container runlabel label settings.