### PR TITLE
Add playbook to setup kea_dhcp workload on the ALP host

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,4 +241,22 @@ alphost                    : ok=8   changed=4    unreachable=0    failed=0    sk
 
 ```
 
-For more details, you can refer to the [SUSE ALP Micro documentation](https://documentation.suse.com/alp/micro/html/alp-micro/available-alp-workloads.html#task-run-neuvector-with-podman).
+For more details, you can refer to the [SUSE ALP documentation](https://documentation.suse.com/alp/dolomite/html/alp-dolomite/available-alp-workloads.html#task-run-neuvector-with-podman).
+
+## Setup Kea DHCP Server on ALP Host
+
+The setup_kea_dhcp_server.yml playbook automates the deployment and management of the Kea DHCP server workload on an ALP host. The inclusion of the -e run_dhcpv6=true argument allows users to enable the DHCPv6 functionalities when desired.
+
+```shell
+$ cd /usr/local/share/ansible-container/examples/ansible
+$ ansible-playbook setup_kea_dhcp_server.yml -e run_dhcpv6=true
+...
+TASK [Start Kea DHCPv6 server using systemd] *********************************************************************************************************************************************************************
+changed: [alphost]
+
+PLAY RECAP *******************************************************************************************************************************************************************************************************
+alphost                    : ok=6    changed=5    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0  
+
+```
+
+NOTE: The playbook allows for custom configuration templates for DHCPv4 and DHCPv6. If using custom templates, ensure they're appropriately formatted and paths are correctly specified in the playbook variables. The Kea configuration files—kea-dhcp4.conf and kea-dhcp6.conf—are located in the /etc/kea directory. They include the default configuration. You can find detailed information about configuring the DHCP server in the official documentation at https://kea.readthedocs.io/

--- a/examples/ansible/setup_kea_dhcp_server.yml
+++ b/examples/ansible/setup_kea_dhcp_server.yml
@@ -69,6 +69,8 @@
             name: kea-dhcp4.service
             state: started
             enabled: yes
+          when:
+            - not run_dhcpv6
 
         - name: Start Kea DHCPv6 server using systemd
           ansible.builtin.systemd:

--- a/examples/ansible/setup_kea_dhcp_server.yml
+++ b/examples/ansible/setup_kea_dhcp_server.yml
@@ -81,7 +81,5 @@
   handlers:
     - name: Reload Kea configuration
       ansible.builtin.command: /usr/local/bin/keactrl reload
-      changed_when:
-        - '"Configuration reloaded successfully" in kea_reload_output.stdout'
       when:
         - dhcp4_config.changed or dhcp6_config.changed

--- a/examples/ansible/setup_kea_dhcp_server.yml
+++ b/examples/ansible/setup_kea_dhcp_server.yml
@@ -1,0 +1,87 @@
+---
+# Ansible Playbook: Manage Kea DHCP Server Workload on ALP Host
+# Description: This Ansible playbook automates the setup of the Kea DHCP server workload on an ALP host. It follows the steps documented in the URL provided below.
+# Kea Workload Documentation: https://build.opensuse.org/package/view_file/SUSE:ALP:Workloads/kea-container/README.md?expand=1
+
+# Playbook Variables:
+#   - 'run_dhcpv6': A boolean variable to control the Kea DHCPv6 server. Set to 'true' to start the DHCPv6 server, 'false' to skip it.
+#   - 'dhcp4_template_src': Path to the DHCPv4 configuration j2 template. Leave empty if not using a template.
+#   - 'dhcp6_template_src': Path to the DHCPv6 configuration j2 template. Leave empty if not using a template.
+#   - 'kea_config_path': Path where the Kea DHCP server configuration files will be stored.
+#   - 'workload': A dictionary containing information about the Kea workload, including its name and container image.
+
+- name: Deploying and Managing the Kea DHCP server workload
+  hosts: alphost
+  become: true
+  vars:
+    run_dhcpv6: false
+    dhcp4_template_src: ""
+    dhcp6_template_src: ""
+    kea_config_path: /etc/kea
+    workload:
+      name: kea
+      image: registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/kea:latest
+
+  tasks:
+    - name: Setup Kea DHCP server
+      block:
+        - name: Pull the Kea DHCP server container image
+          containers.podman.podman_image:
+            name: "{{ workload.image }}"
+            state: present
+
+        - name: Install all required parts of the Kea workload
+          ansible.builtin.command: >-
+            podman container runlabel install {{ workload.image }}
+          register: workload_runlabel_install
+          changed_when:
+            - ('already exist' not in workload_runlabel_install.stdout)
+
+        - name: Add firewall exception rule for DHCPv6
+          ansible.posix.firewalld:
+            service: dhcpv6
+            permanent: yes
+            state: enabled
+            immediate: yes
+          when:
+            - run_dhcpv6
+
+        - name: Generate Kea DHCPv4 configuration from template
+          ansible.builtin.template:
+            src: "{{ dhcp4_template_src }}"
+            dest: "{{ kea_config_path }}/kea-dhcp4.conf"
+          register: dhcp4_config
+          notify: Reload Kea configuration
+          when:
+            - dhcp4_template_src != ""
+
+        - name: Generate Kea DHCPv6 configuration from template
+          ansible.builtin.template:
+            src: "{{ dhcp6_template_src }}"
+            dest: "{{ kea_config_path }}/kea-dhcp6.conf"
+          register: dhcp6_config
+          notify: Reload Kea configuration
+          when:
+            - dhcp6_template_src != ""
+
+        - name: Start Kea DHCPv4 server using systemd
+          ansible.builtin.systemd:
+            name: kea-dhcp4.service
+            state: started
+            enabled: yes
+
+        - name: Start Kea DHCPv6 server using systemd
+          ansible.builtin.systemd:
+            name: kea-dhcp6.service
+            state: started
+            enabled: yes
+          when:
+            - run_dhcpv6
+
+  handlers:
+    - name: Reload Kea configuration
+      ansible.builtin.command: /usr/local/bin/keactrl reload
+      changed_when:
+        - '"Configuration reloaded successfully" in kea_reload_output.stdout'
+      when:
+        - dhcp4_config.changed or dhcp6_config.changed


### PR DESCRIPTION
- Automate the setup of Kea DHCP server on ALP host.
- Introduce playbook variables for DHCPv4, DHCPv6, and Kea configuration paths.
- Deploy and manage the Kea DHCP server workload on ALP host.
- Pull Kea DHCP server container image from OpenSUSE registry.
- Install required parts of the Kea workload using podman.
- Add firewall exception rule for DHCPv6.
- Generate Kea DHCPv4 and DHCPv6 configurations from provided templates.
- Start Kea DHCPv4 and DHCPv6 servers using systemd.
- Add handler to reload Kea configuration when changes are detected.

Reference: 
https://build.opensuse.org/package/view_file/SUSE:ALP:Workloads/kea-container/README.md?expand=1
