### PR TITLE
Re-add Keylime setup playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ There are twelve playbooks currently under /usr/local/share/ansible-container/ex
 * setup_kea_dhcpv6_server.yml
 * setup_grafana.yml
 * setup_neuvector.yml
+* setup_keylime.yml
 
 ## VM Creation Playbooks
 * create_alp_vm.yml
@@ -339,3 +340,14 @@ alphost                    : ok=6    changed=4    unreachable=0    failed=0    s
 
 ```
 Upon successful execution of the playbook, access the Grafana interface at http://HOSTNAME_OR_IP_OF_ALP_HOST:3000. When logging in for the first time, use the default credentials admin for both the username and password. Subsequently, set a new password as prompted.
+
+
+## Setup Keylime on ALP Host
+This Ansible playbook automates the deployment and setup of Keylime verifier, registrar and tenant on a SUSE ALP Dolomite host, The steps encompass fetching the Keylime image from the specified registry, creating a necessary volume for the Keylime control plane, launching the Keylime container along with related services, and executing the tenant CLI to interact with Keylime.
+```shell
+$ cd /usr/local/share/ansible-container/examples/ansible
+$ ansible-playbook setup_keylime.yml
+...
+PLAY RECAP ***************************************************************************************************************************************
+alphost                    : ok=7    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```

--- a/examples/ansible/setup_keylime.yml
+++ b/examples/ansible/setup_keylime.yml
@@ -1,0 +1,60 @@
+---
+# Ansible Playbook: Setup Keylime on SUSE ALP Dolomite
+# Description: This Ansible playbook automates the deployment and setup of Keylime verifier, registrar and tenant on a SUSE ALP Dolomite host
+# The steps encompass fetching the Keylime image from the specified registry, creating the necessary volume for the Keylime control plane,
+# launching the Keylime container along with related services, and executing the tenant CLI to interact with Keylime.
+# Documentation reference: [https://documentation.suse.com/alp/dolomite/html/alp-dolomite/keylime-remote-attestation.html#keylime-run-with-podman]
+
+- name: Setup Keylime verifier, registrar and tenant
+  hosts: alptestvm
+  become: true
+  vars:
+    workload:
+      name: keylime
+      image: registry.opensuse.org/devel/microos/containers/containerfile/opensuse/keylime-control-plane:latest
+
+  tasks:
+    - name: Retrieve images for Keylime
+      containers.podman.podman_image:
+        name: "{{ workload.image }}"
+        state: present
+
+    - name: Create the keylime-control-plane volume
+      containers.podman.podman_volume:
+        name: keylime-control-plane-volume
+        state: present
+
+    - name: Start the Keylime container and related services
+      ansible.builtin.command: >-
+        podman container runlabel run "{{ workload.image }}"
+      register: workload_runlabel_run
+      changed_when:
+        - workload_runlabel_run.stdout is regex("^[a-f0-9]{64}$")
+
+    - name: Check Keylime container status
+      containers.podman.podman_container_info:
+        name: keylime-control-plane-container
+      register: container_info
+      until:
+        - container_info.containers[0].State.Running
+      retries: 5
+      delay: 10
+
+    - name: Executing the tenant CLI with retries
+      ansible.builtin.command: >-
+        podman run --rm \
+        -v keylime-control-plane-volume:/var/lib/keylime/ \
+        keylime-control-plane:latest \
+        keylime_tenant -v 10.88.0.1 -r 10.88.0.1 --cert default -c reglist
+      register: podman_run
+      until:
+        - (podman_run.stdout | regex_search('"status":\\s+"Success"')) is not none
+      retries: 5
+      delay: 10
+      changed_when:
+        - podman_run.rc == 0
+
+    - name: Display completion message
+      ansible.builtin.debug:
+        msg: >-
+          "Keylime setup and tenant CLI execution completed successfully."

--- a/examples/ansible/setup_keylime.yml
+++ b/examples/ansible/setup_keylime.yml
@@ -6,7 +6,7 @@
 # Documentation reference: [https://documentation.suse.com/alp/dolomite/html/alp-dolomite/keylime-remote-attestation.html#keylime-run-with-podman]
 
 - name: Setup Keylime verifier, registrar and tenant
-  hosts: alptestvm
+  hosts: alphost
   become: true
   vars:
     workload:


### PR DESCRIPTION
Restoring the Keylime setup playbook that was removed in a previous commit.
